### PR TITLE
fix: ui layout dynamic sizes and constants 

### DIFF
--- a/apps/menu-bar/src/popover/Footer.tsx
+++ b/apps/menu-bar/src/popover/Footer.tsx
@@ -5,13 +5,11 @@ import MenuBarModule from '../modules/MenuBarModule'
 import { WindowsNavigator } from '../windows'
 import Item from './Item'
 
-export const FOOTER_HEIGHT = 62
-
 export default function Footer() {
   const { t } = useTranslation()
 
   return (
-    <View style={styles.container}>
+    <View>
       <View px="medium">
         <Divider />
       </View>
@@ -26,10 +24,3 @@ export default function Footer() {
     </View>
   )
 }
-
-const styles = StyleSheet.create({
-  container: {
-    marginTop: 24,
-    // height: FOOTER_HEIGHT,
-  },
-})

--- a/apps/menu-bar/src/popover/ProjectList.tsx
+++ b/apps/menu-bar/src/popover/ProjectList.tsx
@@ -15,12 +15,11 @@ import {
 } from '../services/preferences'
 import { projectStore } from '../services/projectStore'
 import { setPendingProjectRemove, subscribeProjectRemoveConfirm } from '../services/removeProjectDialog'
+import { MAX_UI_HEIGHT } from '../utils/constants'
 import { WindowsNavigator } from '../windows'
 import Footer from './Footer'
 import { ProjectItem } from './ProjectItem'
 import SectionHeader from './SectionHeader'
-
-const MAX_LIST_HEIGHT = Dimensions.get('screen').height * 0.7
 
 export const ProjectList = () => {
   const { t } = useTranslation()
@@ -157,11 +156,6 @@ export const ProjectList = () => {
     WindowsNavigator.open('RemoveProjectWindow')
   }
 
-  const getListHeight = useMemo(() => {
-    const height = projects.length * 120
-    return height > MAX_LIST_HEIGHT ? MAX_LIST_HEIGHT : height
-  }, [projects])
-
   if (loading) {
     return (
       <View style={styles.emptyContainer}>
@@ -171,7 +165,11 @@ export const ProjectList = () => {
   }
 
   return (
-    <>
+    <View
+      style={{
+        maxHeight: MAX_UI_HEIGHT,
+      }}
+    >
       <SectionHeader
         label={t('projects')}
         accessoryRight={
@@ -188,7 +186,6 @@ export const ProjectList = () => {
       <FlatList
         data={projects}
         keyExtractor={(item) => item.id}
-        style={{ height: getListHeight }}
         ListEmptyComponent={
           <View style={styles.emptyContainer}>
             <Text style={styles.emptyText}>{t('noProjectsYet')}</Text>
@@ -222,8 +219,9 @@ export const ProjectList = () => {
           />
         )}
       />
+
       <Footer />
-    </>
+    </View>
   )
 }
 

--- a/apps/menu-bar/src/popover/SectionHeader.tsx
+++ b/apps/menu-bar/src/popover/SectionHeader.tsx
@@ -27,5 +27,5 @@ const SectionHeader = ({ accessoryRight, label, style }: Props) => {
 export default memo(SectionHeader)
 
 const styles = StyleSheet.create({
-  row: { height: SECTION_HEADER_HEIGHT },
+  row: { paddingVertical: 4 },
 })

--- a/apps/menu-bar/src/utils/constants.ts
+++ b/apps/menu-bar/src/utils/constants.ts
@@ -1,3 +1,4 @@
+import { Dimensions } from 'react-native'
 import { Linking } from '../modules/Linking'
 import MenuBarModule from '../modules/MenuBarModule'
 
@@ -5,3 +6,5 @@ export const openProjectsSelectorURL = () => {
   Linking.openURL('https://expo.dev/accounts/[account]/projects/[project]/builds')
   MenuBarModule.closePopover()
 }
+
+export const MAX_UI_HEIGHT = Dimensions.get('screen').height * 0.75


### PR DESCRIPTION
This pull request refactors the UI height management in the menu bar popover components, centralizing the maximum allowed UI height into a shared constant and simplifying related styles. The changes improve maintainability and consistency across components.

**UI Height Management Refactor:**

* Introduced a new constant `MAX_UI_HEIGHT` in `utils/constants.ts` to standardize the maximum UI height, set to 75% of the screen height.
* Updated `ProjectList` to use `MAX_UI_HEIGHT` for its maximum height, removing the previous inline calculation and the `getListHeight` logic. [[1]](diffhunk://#diff-caa5d326c42546aa3a27e78d8495c9aa8a188cc5d732dc480d08163c4015b48bR18-L24) [[2]](diffhunk://#diff-caa5d326c42546aa3a27e78d8495c9aa8a188cc5d732dc480d08163c4015b48bL160-L164) [[3]](diffhunk://#diff-caa5d326c42546aa3a27e78d8495c9aa8a188cc5d732dc480d08163c4015b48bL174-R172) [[4]](diffhunk://#diff-caa5d326c42546aa3a27e78d8495c9aa8a188cc5d732dc480d08163c4015b48bL191) [[5]](diffhunk://#diff-caa5d326c42546aa3a27e78d8495c9aa8a188cc5d732dc480d08163c4015b48bR222-R224)

**Style Simplification and Cleanup:**

* Removed the unused `FOOTER_HEIGHT` constant and the `styles.container` style from `Footer.tsx`, and simplified its container structure. [[1]](diffhunk://#diff-0aa6c19c84346d6da5cac95abb9466bb8a09fb95f827de8cfdc495a0234f5a62L8-R12) [[2]](diffhunk://#diff-0aa6c19c84346d6da5cac95abb9466bb8a09fb95f827de8cfdc495a0234f5a62L29-L35)
* Adjusted the `SectionHeader` row style to use vertical padding instead of a fixed height for better flexibility.