### PR TITLE
feat(menu-bar): add startup and app icon settings with Electron fixes

### DIFF
--- a/apps/cli/src/storage.ts
+++ b/apps/cli/src/storage.ts
@@ -102,6 +102,7 @@ const defaultPreferences: Settings = {
   defaultEditor: null,
   defaultTerminal: null,
   launchOnLogin: false,
+  showAppIcons: false,
   removeFromDiskByDefault: false,
   customEditors: [],
   customTerminals: [],

--- a/apps/menu-bar/electron/forge.config.ts
+++ b/apps/menu-bar/electron/forge.config.ts
@@ -28,7 +28,7 @@ const linuxOptions: LinuxOptions = {
 
 const config: ForgeConfig = {
   packagerConfig: {
-    icon: './assets/images/icon-windows',
+    icon: '../../../assets/icon',
     executableName: 'tray-link',
     name: 'Tray Link',
     extraResource: './assets',

--- a/apps/menu-bar/electron/src/TrayGenerator.ts
+++ b/apps/menu-bar/electron/src/TrayGenerator.ts
@@ -90,9 +90,8 @@ export default class TrayGenerator {
             // Keep in sync with menu-bar/src/windows/index.ts
             title: 'Settings',
             windowStyle: {
-              titlebarAppearsTransparent: true,
-              height: 580,
-              width: 500,
+              height: 640,
+              width: 600,
             },
           })
         },

--- a/apps/menu-bar/macos/TrayLink-macOS/Info.plist
+++ b/apps/menu-bar/macos/TrayLink-macOS/Info.plist
@@ -48,7 +48,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIconFile</key>
-	<string></string>
+	<string>AppIcon</string>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>

--- a/apps/menu-bar/modules/shell-utils/electron/main.ts
+++ b/apps/menu-bar/modules/shell-utils/electron/main.ts
@@ -39,14 +39,12 @@ function createWrapperScript(): string {
   const isWindows = process.platform === 'win32'
 
   if (isWindows) {
-    // Windows batch wrapper — uses node from PATH at runtime
     const wrapperPath = path.join(wrapperDir, `${CLI_BINARY_NAME}.cmd`)
     const content = `@echo off\r\nnode "${cliJs}" %*\r\n`
     fs.writeFileSync(wrapperPath, content, { encoding: 'utf8' })
     return wrapperPath
   }
 
-  // Unix shell wrapper — resolves node at runtime from user's PATH
   const wrapperPath = path.join(wrapperDir, CLI_BINARY_NAME)
   const content = [
     '#!/bin/sh',
@@ -62,6 +60,104 @@ function createWrapperScript(): string {
   ].join('\n')
   fs.writeFileSync(wrapperPath, content, { mode: 0o755, encoding: 'utf8' })
   return wrapperPath
+}
+
+function getBundleResourceIconCandidates(appPath: string, iconName?: string | null): string[] {
+  const resourcesDir = path.join(appPath, 'Contents', 'Resources')
+  const normalizedIconName = iconName ? iconName.replace(/\.icns$/i, '') : null
+  const basenames = [normalizedIconName, 'AppIcon', 'app', path.basename(appPath, '.app')].filter(
+    (value): value is string => Boolean(value),
+  )
+
+  return [
+    ...new Set(
+      basenames.flatMap((basename) => [
+        path.join(resourcesDir, `${basename}.icns`),
+        path.join(resourcesDir, `${basename}.png`),
+      ]),
+    ),
+  ]
+}
+
+function toDataUrl(mimeType: string, buffer: Buffer): string {
+  return `data:${mimeType};base64,${buffer.toString('base64')}`
+}
+
+async function getImageFileDataUrl(iconPath: string): Promise<string | null> {
+  try {
+    const extension = path.extname(iconPath).toLowerCase()
+
+    if (extension === '.png') {
+      return toDataUrl('image/png', fs.readFileSync(iconPath))
+    }
+
+    if (extension === '.icns') {
+      const outputPath = path.join(
+        os.tmpdir(),
+        `tray-link-icon-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}.png`,
+      )
+
+      try {
+        await execAsync(
+          `sips -s format png "${iconPath.replace(/"/g, '\\"')}" --out "${outputPath.replace(/"/g, '\\"')}"`,
+        )
+        if (!fs.existsSync(outputPath)) {
+          return null
+        }
+
+        return toDataUrl('image/png', fs.readFileSync(outputPath))
+      } finally {
+        if (fs.existsSync(outputPath)) {
+          fs.rmSync(outputPath, { force: true })
+        }
+      }
+    }
+  } catch {
+    return null
+  }
+
+  return null
+}
+
+async function getMacOSBundleIconName(appPath: string): Promise<string | null> {
+  const plistPath = path.join(appPath, 'Contents', 'Info.plist')
+  if (!fs.existsSync(plistPath)) {
+    return null
+  }
+
+  try {
+    const { stdout } = await execAsync(`plutil -convert json -o - "${plistPath.replace(/"/g, '\\"')}"`)
+    const plist = JSON.parse(stdout) as {
+      CFBundleIconFile?: string
+      CFBundleIconName?: string
+    }
+
+    return plist.CFBundleIconFile || plist.CFBundleIconName || null
+  } catch {
+    return null
+  }
+}
+
+async function getMacOSBundleIconDataUrl(appPath: string): Promise<string | null> {
+  try {
+    const iconName = await getMacOSBundleIconName(appPath)
+    const candidates = getBundleResourceIconCandidates(appPath, iconName)
+
+    for (const candidate of candidates) {
+      if (!fs.existsSync(candidate)) {
+        continue
+      }
+
+      const dataUrl = await getImageFileDataUrl(candidate)
+      if (dataUrl) {
+        return dataUrl
+      }
+    }
+  } catch {
+    return null
+  }
+
+  return null
 }
 
 export const ShellUtilsMain = {
@@ -111,6 +207,13 @@ export const ShellUtilsMain = {
     try {
       if (!fs.existsSync(targetPath)) {
         return null
+      }
+
+      if (process.platform === 'darwin' && targetPath.endsWith('.app')) {
+        const bundleIcon = await getMacOSBundleIconDataUrl(targetPath)
+        if (bundleIcon) {
+          return bundleIcon
+        }
       }
 
       const icon = await app.getFileIcon(targetPath, { size: 'small' })

--- a/apps/menu-bar/modules/shell-utils/electron/main.ts
+++ b/apps/menu-bar/modules/shell-utils/electron/main.ts
@@ -1,4 +1,5 @@
 import { exec } from 'child_process'
+import { app } from 'electron'
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
@@ -104,6 +105,22 @@ export const ShellUtilsMain = {
       return fs.existsSync(path)
     } catch {
       return false
+    }
+  },
+  getFileIconDataUrl: async (targetPath: string) => {
+    try {
+      if (!fs.existsSync(targetPath)) {
+        return null
+      }
+
+      const icon = await app.getFileIcon(targetPath, { size: 'small' })
+      if (icon.isEmpty()) {
+        return null
+      }
+
+      return icon.toDataURL()
+    } catch {
+      return null
     }
   },
   loadLegacyTrayLinkData: async () => {

--- a/apps/menu-bar/modules/shell-utils/src/index.macos.ts
+++ b/apps/menu-bar/modules/shell-utils/src/index.macos.ts
@@ -23,6 +23,10 @@ export function fileExists(path: string): Promise<boolean> {
   return ShellUtilsModule.fileExists(path)
 }
 
+export function getFileIconDataUrl(_path: string): Promise<string | null> {
+  return Promise.resolve(null)
+}
+
 export function loadLegacyTrayLinkData(): Promise<Record<string, unknown> | null> {
   return ShellUtilsModule.loadLegacyTrayLinkData()
 }

--- a/apps/menu-bar/modules/shell-utils/src/index.ts
+++ b/apps/menu-bar/modules/shell-utils/src/index.ts
@@ -8,6 +8,7 @@ type ShellUtilsModuleType = {
   openInFinder: (path: string) => Promise<boolean>
   which: (binary: string) => Promise<string | null>
   fileExists: (path: string) => Promise<boolean>
+  getFileIconDataUrl: (path: string) => Promise<string | null>
   loadLegacyTrayLinkData: () => Promise<Record<string, unknown> | null>
   removeFromDisk: (path: string) => Promise<boolean>
   isCliInstalled: () => Promise<boolean>
@@ -34,6 +35,7 @@ if (isElectron) {
       openInFinder: async () => false,
       which: async () => null,
       fileExists: async () => false,
+      getFileIconDataUrl: async () => null,
       loadLegacyTrayLinkData: async () => null,
       removeFromDisk: async () => false,
       isCliInstalled: async () => false,
@@ -61,6 +63,10 @@ export function which(binary: string): Promise<string | null> {
 
 export function fileExists(path: string): Promise<boolean> {
   return ShellUtilsModule.fileExists(path)
+}
+
+export function getFileIconDataUrl(path: string): Promise<string | null> {
+  return ShellUtilsModule.getFileIconDataUrl(path)
 }
 
 export function loadLegacyTrayLinkData(): Promise<Record<string, unknown> | null> {

--- a/apps/menu-bar/src/components/AppIcon/index.tsx
+++ b/apps/menu-bar/src/components/AppIcon/index.tsx
@@ -1,0 +1,18 @@
+import React, { useState } from 'react'
+import { Image, ImageStyle, StyleProp } from 'react-native'
+
+type Props = {
+  uri: string
+  style?: StyleProp<ImageStyle>
+  fallback?: React.ReactNode
+}
+
+export function AppIcon({ uri, style, fallback = null }: Props) {
+  const [failed, setFailed] = useState(false)
+
+  if (!uri || failed) {
+    return <>{fallback}</>
+  }
+
+  return <Image source={{ uri }} style={style} onError={() => setFailed(true)} />
+}

--- a/apps/menu-bar/src/components/AppIcon/index.web.tsx
+++ b/apps/menu-bar/src/components/AppIcon/index.web.tsx
@@ -1,0 +1,35 @@
+import React, { useMemo, useState } from 'react'
+import { ImageStyle, StyleProp, StyleSheet } from 'react-native'
+
+type Props = {
+  uri: string
+  style?: StyleProp<ImageStyle>
+  fallback?: React.ReactNode
+}
+
+const flattenStyle = (style?: StyleProp<ImageStyle>): React.CSSProperties => {
+  return (StyleSheet.flatten(style) ?? {}) as React.CSSProperties
+}
+
+export function AppIcon({ uri, style, fallback = null }: Props) {
+  const [failed, setFailed] = useState(false)
+  const resolvedStyle = useMemo(() => flattenStyle(style), [style])
+
+  if (!uri || failed) {
+    return <>{fallback}</>
+  }
+
+  return (
+    <img
+      src={uri}
+      alt=""
+      draggable={false}
+      onError={() => setFailed(true)}
+      style={{
+        display: 'block',
+        objectFit: 'cover',
+        ...resolvedStyle,
+      }}
+    />
+  )
+}

--- a/apps/menu-bar/src/components/ScrollView/index.tsx
+++ b/apps/menu-bar/src/components/ScrollView/index.tsx
@@ -1,0 +1,1 @@
+export { ScrollView } from 'react-native'

--- a/apps/menu-bar/src/components/ScrollView/index.web.tsx
+++ b/apps/menu-bar/src/components/ScrollView/index.web.tsx
@@ -1,0 +1,35 @@
+import React, { PropsWithChildren } from 'react'
+import { StyleProp, StyleSheet, ViewStyle } from 'react-native'
+
+type Props = PropsWithChildren<{
+  style?: StyleProp<ViewStyle>
+  contentContainerStyle?: StyleProp<ViewStyle>
+  showsVerticalScrollIndicator?: boolean
+}>
+
+const flattenStyle = (style?: StyleProp<ViewStyle>): React.CSSProperties => {
+  return (StyleSheet.flatten(style) ?? {}) as React.CSSProperties
+}
+
+export function ScrollView({ children, style, contentContainerStyle }: Props) {
+  return (
+    <div
+      style={{
+        flex: 1,
+        overflowY: 'auto',
+        overflowX: 'hidden',
+        minHeight: 0,
+        ...flattenStyle(style),
+      }}
+    >
+      <div
+        style={{
+          minHeight: '100%',
+          ...flattenStyle(contentContainerStyle),
+        }}
+      >
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/apps/menu-bar/src/components/Switch/index.web.tsx
+++ b/apps/menu-bar/src/components/Switch/index.web.tsx
@@ -1,16 +1,45 @@
-import { Switch as FluentSwitch } from '@fluentui/react-switch'
+import React from 'react'
 import { SwitchProps } from 'react-native'
 
 export function Switch({ onValueChange, value, disabled }: SwitchProps) {
   return (
-    <FluentSwitch
+    <button
+      type="button"
+      role="switch"
+      aria-checked={value}
+      aria-disabled={disabled}
       disabled={disabled}
-      checked={value}
-      onChange={(ev) => {
-        if (onValueChange) {
-          onValueChange(Boolean(ev.target.checked))
+      onClick={() => {
+        if (!disabled) {
+          onValueChange?.(!value)
         }
       }}
-    />
+      style={{
+        width: 36,
+        height: 20,
+        borderRadius: 999,
+        border: '1px solid rgba(255,255,255,0.14)',
+        backgroundColor: value ? 'var(--accent-color, #3b82f6)' : 'rgba(255,255,255,0.12)',
+        padding: 1,
+        position: 'relative',
+        transition: 'background-color 120ms ease, border-color 120ms ease, opacity 120ms ease',
+        opacity: disabled ? 0.5 : 1,
+        cursor: disabled ? 'not-allowed' : 'pointer',
+        boxShadow: value ? '0 0 0 1px rgba(59,130,246,0.18)' : 'none',
+      }}
+    >
+      <span
+        style={{
+          display: 'block',
+          width: 16,
+          height: 16,
+          borderRadius: 999,
+          backgroundColor: '#fff',
+          transform: value ? 'translateX(16px)' : 'translateX(0px)',
+          transition: 'transform 120ms ease',
+          boxShadow: '0 1px 2px rgba(0,0,0,0.24)',
+        }}
+      />
+    </button>
   )
 }

--- a/apps/menu-bar/src/components/index.ts
+++ b/apps/menu-bar/src/components/index.ts
@@ -1,4 +1,7 @@
+export { AppIcon } from './AppIcon'
 export { default as Button } from './Button'
 export { default as Checkbox } from './Checkbox'
+export { ScrollView } from './ScrollView'
+export { Switch } from './Switch'
 export { Text, TextInput } from './Text'
 export { Divider, Row, Spacer, View } from './View'

--- a/apps/menu-bar/src/modules/Storage.ts
+++ b/apps/menu-bar/src/modules/Storage.ts
@@ -7,6 +7,7 @@ export type UserPreferences = Settings
 
 export const defaultUserPreferences: UserPreferences = {
   launchOnLogin: false,
+  showAppIcons: false,
   locale: 'en',
   defaultEditor: null,
   defaultTerminal: null,

--- a/apps/menu-bar/src/popover/ProjectItem.tsx
+++ b/apps/menu-bar/src/popover/ProjectItem.tsx
@@ -3,6 +3,7 @@ import { Project } from '@tray-link/common-types'
 import React from 'react'
 import { StyleSheet, TouchableOpacity, View } from 'react-native'
 
+import { AppIcon } from '../components'
 import { Text } from '../components/Text'
 
 type Props = {
@@ -14,8 +15,18 @@ type Props = {
   onRemove: () => void
   onToggleContextMenu: () => void
   contextMenuOpen?: boolean
-  editorOptions: Array<{ label: string; command: string }>
-  terminalOptions: Array<{ label: string; command: string }>
+  editorOptions: Array<{
+    label: string
+    command: string
+    iconName?: 'code-slash-outline' | 'terminal-outline'
+    iconPath?: string | null
+  }>
+  terminalOptions: Array<{
+    label: string
+    command: string
+    iconName?: 'code-slash-outline' | 'terminal-outline'
+    iconPath?: string | null
+  }>
   onOpenWithEditor: (command: string) => void
   onOpenWithTerminal: (command: string) => void
   labels: {
@@ -120,6 +131,13 @@ export const ProjectItem = ({
                 style={styles.contextActionButton}
                 onPress={() => onOpenWithEditor(option.command)}
               >
+                <AppIcon
+                  uri={option.iconPath ?? ''}
+                  style={styles.contextActionIconImage}
+                  fallback={
+                    <Ionicons name={option.iconName ?? 'code-slash-outline'} size={12} color="var(--text-color)" />
+                  }
+                />
                 <Text style={styles.contextActionText}>{option.label}</Text>
               </TouchableOpacity>
             ))}
@@ -133,6 +151,13 @@ export const ProjectItem = ({
                 style={styles.contextActionButton}
                 onPress={() => onOpenWithTerminal(option.command)}
               >
+                <AppIcon
+                  uri={option.iconPath ?? ''}
+                  style={styles.contextActionIconImage}
+                  fallback={
+                    <Ionicons name={option.iconName ?? 'terminal-outline'} size={12} color="var(--text-color)" />
+                  }
+                />
                 <Text style={styles.contextActionText}>{option.label}</Text>
               </TouchableOpacity>
             ))}
@@ -207,10 +232,18 @@ const styles = StyleSheet.create({
     gap: 6,
   },
   contextActionButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
     borderRadius: 6,
     paddingHorizontal: 8,
     paddingVertical: 4,
     backgroundColor: 'rgba(255,255,255,0.1)',
+  },
+  contextActionIconImage: {
+    width: 16,
+    height: 16,
+    borderRadius: 4,
   },
   contextActionText: {
     fontSize: 11,

--- a/apps/menu-bar/src/popover/ProjectList.tsx
+++ b/apps/menu-bar/src/popover/ProjectList.tsx
@@ -30,8 +30,20 @@ export const ProjectList = () => {
   const [editMode, setEditMode] = useState(false)
   const [contextMenuProjectId, setContextMenuProjectId] = useState<string | null>(null)
   const [preferences, setPreferences] = useState(defaultUserPreferences)
-  const editorOptions = getEditorOptions(preferences.customEditors)
-  const terminalOptions = getTerminalOptions(preferences.customTerminals)
+  const editorOptions = useMemo(
+    () =>
+      getEditorOptions(preferences.customEditors).map((option) =>
+        preferences.showAppIcons ? option : { ...option, iconPath: null },
+      ),
+    [preferences.customEditors, preferences.showAppIcons],
+  )
+  const terminalOptions = useMemo(
+    () =>
+      getTerminalOptions(preferences.customTerminals).map((option) =>
+        preferences.showAppIcons ? option : { ...option, iconPath: null },
+      ),
+    [preferences.customTerminals, preferences.showAppIcons],
+  )
 
   useEffect(() => {
     loadProjects()

--- a/apps/menu-bar/src/providers/FluentProvider/index.web.tsx
+++ b/apps/menu-bar/src/providers/FluentProvider/index.web.tsx
@@ -27,7 +27,15 @@ export const FluentProvider = ({ children, style }: { children: ReactElement; st
 export const withFluentProvider = <P extends object>(WrappedComponent: ComponentType<P>) => {
   const WithFluentProvider = (props: P) => {
     return (
-      <FluentProvider style={{ display: 'flex', width: '100%' }}>
+      <FluentProvider
+        style={{
+          display: 'flex',
+          width: '100%',
+          height: '100%',
+          flex: 1,
+          minHeight: 0,
+        }}
+      >
         <WrappedComponent {...props} />
       </FluentProvider>
     )

--- a/apps/menu-bar/src/services/i18n.ts
+++ b/apps/menu-bar/src/services/i18n.ts
@@ -13,6 +13,8 @@ type TranslationKey =
   | 'defaultEditor'
   | 'defaultTerminal'
   | 'systemDefault'
+  | 'openOnStartup'
+  | 'showAppIcons'
   | 'deleteFilesFromDiskByDefault'
   | 'addCustomEditor'
   | 'addCustomTerminal'
@@ -65,6 +67,8 @@ export const dictionaries: Record<Locale, Record<TranslationKey, string>> = {
     defaultEditor: 'Default editor',
     defaultTerminal: 'Default terminal',
     systemDefault: 'System default',
+    openOnStartup: 'Open on startup',
+    showAppIcons: 'Show real app icons',
     deleteFilesFromDiskByDefault: 'Delete files from disk by default',
     addCustomEditor: 'Add custom editor',
     addCustomTerminal: 'Add custom terminal',
@@ -116,6 +120,8 @@ export const dictionaries: Record<Locale, Record<TranslationKey, string>> = {
     defaultEditor: 'Editor padrão',
     defaultTerminal: 'Terminal padrão',
     systemDefault: 'Padrão do sistema',
+    openOnStartup: 'Abrir na inicialização',
+    showAppIcons: 'Mostrar ícones reais dos apps',
     deleteFilesFromDiskByDefault: 'Excluir arquivos do disco por padrão',
     addCustomEditor: 'Adicionar editor personalizado',
     addCustomTerminal: 'Adicionar terminal personalizado',
@@ -167,6 +173,8 @@ export const dictionaries: Record<Locale, Record<TranslationKey, string>> = {
     defaultEditor: 'Editor predeterminado',
     defaultTerminal: 'Terminal predeterminado',
     systemDefault: 'Predeterminado del sistema',
+    openOnStartup: 'Abrir al iniciar',
+    showAppIcons: 'Mostrar iconos reales de las apps',
     deleteFilesFromDiskByDefault: 'Eliminar archivos del disco por defecto',
     addCustomEditor: 'Agregar editor personalizado',
     addCustomTerminal: 'Agregar terminal personalizado',

--- a/apps/menu-bar/src/services/i18n.ts
+++ b/apps/menu-bar/src/services/i18n.ts
@@ -47,6 +47,7 @@ type TranslationKey =
   | 'openWithTerminal'
   | 'reload'
   | 'reloadToolList'
+  | 'advanced'
   | 'migrateLegacyData'
   | 'migrationPreviewFound'
   | 'migrationPreviewNone'
@@ -101,6 +102,7 @@ export const dictionaries: Record<Locale, Record<TranslationKey, string>> = {
     openWithTerminal: 'Open with terminal',
     reload: 'Reload',
     reloadToolList: 'Reload editors and terminals',
+    advanced: 'Advanced',
     migrateLegacyData: 'Migrate legacy data',
     migrationPreviewFound: 'Legacy data found: {{projects}} projects',
     migrationPreviewNone: 'No legacy data found',
@@ -154,6 +156,7 @@ export const dictionaries: Record<Locale, Record<TranslationKey, string>> = {
     openWithTerminal: 'Abrir com terminal',
     reload: 'Recarregar',
     reloadToolList: 'Recarregar lista de editores e terminais',
+    advanced: 'Avançado',
     migrateLegacyData: 'Migrar dados legados',
     migrationPreviewFound: 'Dados legados encontrados: {{projects}} projetos',
     migrationPreviewNone: 'Nenhum dado legado encontrado',
@@ -207,6 +210,7 @@ export const dictionaries: Record<Locale, Record<TranslationKey, string>> = {
     openWithTerminal: 'Abrir con terminal',
     reload: 'Recargar',
     reloadToolList: 'Recargar lista de editores y terminales',
+    advanced: 'Avanzado',
     migrateLegacyData: 'Migrar datos legados',
     migrationPreviewFound: 'Datos heredados encontrados: {{projects}} proyectos',
     migrationPreviewNone: 'No se encontraron datos heredados',

--- a/apps/menu-bar/src/services/preferences.ts
+++ b/apps/menu-bar/src/services/preferences.ts
@@ -1,7 +1,8 @@
 import { CustomTool } from '@tray-link/common-types'
-import { EmitterSubscription } from 'react-native'
-import { fileExists, which } from '../../modules/shell-utils/src'
+import { EmitterSubscription, Platform } from 'react-native'
+import { fileExists, getFileIconDataUrl, which } from '../../modules/shell-utils/src'
 import { DeviceEventEmitter } from '../modules/DeviceEventEmitter'
+import MenuBarModule from '../modules/MenuBarModule'
 import {
   defaultUserPreferences,
   getUserPreferences,
@@ -21,6 +22,8 @@ export type ToolOption = {
   label: string
   command: string
   slug: string
+  iconName?: 'code-slash-outline' | 'terminal-outline'
+  iconPath?: string | null
 }
 
 type DiscoverableTool = {
@@ -28,7 +31,70 @@ type DiscoverableTool = {
   command: string
   binary?: string
   commonFilepaths?: string[]
+  iconBasenames?: string[]
   alwaysAvailable?: boolean
+}
+
+const toFileUri = (filepath: string): string => {
+  if (filepath.startsWith('file://')) {
+    return filepath
+  }
+
+  return `file://${filepath}`
+}
+
+const stripAppExtension = (name: string): string => name.replace(/\.app$/i, '')
+
+const unique = (values: Array<string | null | undefined>): string[] => {
+  return [...new Set(values.filter((value): value is string => Boolean(value)))]
+}
+
+const resolveIconCandidatePaths = (tool: DiscoverableTool, filepath: string): string[] => {
+  const appName = stripAppExtension(filepath.split('/').pop() ?? '')
+  const normalized = appName.replace(/\s+/g, '')
+  const iconBasenames = unique([
+    ...(tool.iconBasenames ?? []),
+    appName,
+    normalized,
+    `${normalized}2`,
+    'AppIcon',
+    'Electron',
+    'app',
+  ])
+
+  return iconBasenames.flatMap((baseName) => [
+    `${filepath}/Contents/Resources/${baseName}.icns`,
+    `${filepath}/Contents/Resources/${baseName}.png`,
+  ])
+}
+
+const resolveIconPath = async (tool: DiscoverableTool): Promise<string | null> => {
+  for (const filepath of tool.commonFilepaths ?? []) {
+    if (Platform.OS === 'web') {
+      const iconDataUrl = await getFileIconDataUrl(filepath)
+      if (iconDataUrl) {
+        return iconDataUrl
+      }
+    }
+
+    if (filepath.endsWith('.png') || filepath.endsWith('.ico') || filepath.endsWith('.icns')) {
+      if (await fileExists(filepath)) {
+        return toFileUri(filepath)
+      }
+    }
+
+    if (filepath.endsWith('.app')) {
+      const candidatePaths = resolveIconCandidatePaths(tool, filepath)
+
+      for (const candidate of candidatePaths) {
+        if (await fileExists(candidate)) {
+          return toFileUri(candidate)
+        }
+      }
+    }
+  }
+
+  return null
 }
 
 const EDITOR_CANDIDATES: DiscoverableTool[] = [
@@ -38,10 +104,12 @@ const EDITOR_CANDIDATES: DiscoverableTool[] = [
     binary: 'code',
     commonFilepaths: [
       '/Applications/Visual Studio Code.app',
+      '/Applications/Visual Studio Code - OSS.app',
       '/usr/share/code/bin/code',
       'C:\\Program Files\\Microsoft VS Code\\Code.exe',
       'C:\\Users\\%USERNAME%\\AppData\\Local\\Programs\\Microsoft VS Code\\Code.exe',
     ],
+    iconBasenames: ['Code', 'AppIcon', 'Visual Studio Code'],
   },
   {
     label: 'Visual Studio Code Insiders',
@@ -137,15 +205,18 @@ const EDITOR_CANDIDATES: DiscoverableTool[] = [
     command: 'open -a "Android Studio"',
     commonFilepaths: [
       '/Applications/Android Studio.app',
+      '/Applications/Android Studio Preview.app',
       '/usr/share/android-studio/bin/studio.sh',
       'C:\\Program Files\\Android\\Android Studio\\bin\\studio64.exe',
     ],
+    iconBasenames: ['studio', 'studio64', 'AndroidStudio', 'AppIcon'],
   },
   {
     label: 'Xcode',
     command: 'xed -b',
     binary: 'xed',
     commonFilepaths: ['/Applications/Xcode.app'],
+    iconBasenames: ['Xcode', 'AppIcon'],
   },
   {
     label: 'Geany',
@@ -173,6 +244,7 @@ const TERMINAL_CANDIDATES: DiscoverableTool[] = [
     command: 'open -a iTerm',
     binary: 'iterm',
     commonFilepaths: ['/Applications/iTerm.app'],
+    iconBasenames: ['iTerm2', 'iTerm'],
   },
   {
     label: 'Warp',
@@ -221,8 +293,13 @@ export const loadPreferences = async (): Promise<UserPreferences> => {
   return { ...defaultUserPreferences, ...stored }
 }
 
+const syncLaunchOnLoginPreference = async (preferences: UserPreferences): Promise<void> => {
+  await MenuBarModule.setLoginItemEnabled(Boolean(preferences.launchOnLogin))
+}
+
 export const persistPreferences = async (next: UserPreferences): Promise<void> => {
   await saveUserPreferences(next)
+  await syncLaunchOnLoginPreference(next)
   DeviceEventEmitter.emit(PREFERENCES_CHANGED_EVENT)
 }
 
@@ -232,6 +309,8 @@ export const persistPreferences = async (next: UserPreferences): Promise<void> =
  */
 export const initializePreferences = async (): Promise<void> => {
   await migratePreferencesFromMMKV()
+  const preferences = await loadPreferences()
+  await syncLaunchOnLoginPreference(preferences)
   await initializeToolOptions()
 }
 
@@ -266,13 +345,23 @@ const isToolInstalled = async (tool: DiscoverableTool): Promise<boolean> => {
   return false
 }
 
-const discoverTools = async (candidates: DiscoverableTool[]): Promise<ToolOption[]> => {
+const discoverTools = async (
+  candidates: DiscoverableTool[],
+  iconName: ToolOption['iconName'],
+): Promise<ToolOption[]> => {
   const discovered: ToolOption[] = []
 
   for (const tool of candidates) {
     const installed = await isToolInstalled(tool)
     if (installed) {
-      discovered.push({ label: tool.label, command: tool.command, slug: generateSlug(tool.label) })
+      const iconPath = await resolveIconPath(tool)
+      discovered.push({
+        label: tool.label,
+        command: tool.command,
+        slug: generateSlug(tool.label),
+        iconName,
+        iconPath,
+      })
     }
   }
 
@@ -282,8 +371,8 @@ const discoverTools = async (candidates: DiscoverableTool[]): Promise<ToolOption
 export const reloadToolOptions = async () => {
   try {
     const [editors, terminals] = await Promise.all([
-      discoverTools(EDITOR_CANDIDATES),
-      discoverTools(TERMINAL_CANDIDATES),
+      discoverTools(EDITOR_CANDIDATES, 'code-slash-outline'),
+      discoverTools(TERMINAL_CANDIDATES, 'terminal-outline'),
     ])
 
     discoveredEditorOptions = dedupeOptions(editors)
@@ -307,6 +396,8 @@ export const getEditorOptions = (customEditors: CustomTool[] = []): ToolOption[]
     label: item.name,
     command: item.command,
     slug: generateSlug(item.name),
+    iconName: 'code-slash-outline' as const,
+    iconPath: null,
   }))
   return dedupeOptions([...discoveredEditorOptions, ...custom])
 }
@@ -316,6 +407,8 @@ export const getTerminalOptions = (customTerminals: CustomTool[] = []): ToolOpti
     label: item.name,
     command: item.command,
     slug: generateSlug(item.name),
+    iconName: 'terminal-outline' as const,
+    iconPath: null,
   }))
   return dedupeOptions([...discoveredTerminalOptions, ...custom])
 }

--- a/apps/menu-bar/src/windows/RemoveProjectWindow.tsx
+++ b/apps/menu-bar/src/windows/RemoveProjectWindow.tsx
@@ -1,6 +1,8 @@
 import React, { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { StyleSheet, Switch, Text, TouchableOpacity, View } from 'react-native'
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native'
+
+import { Switch } from '../components'
 
 import {
   clearPendingProjectRemove,

--- a/apps/menu-bar/src/windows/Settings.tsx
+++ b/apps/menu-bar/src/windows/Settings.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next'
 import { StyleSheet, TouchableOpacity } from 'react-native'
 import { installCli, isCliInstalled, uninstallCli } from '../../modules/shell-utils/src'
 import Analytics, { AnalyticsEvent } from '../analytics'
-import { Checkbox, Divider, Row, Text, View } from '../components'
+import { Divider, Row, ScrollView, Switch, Text, View } from '../components'
 import { Linking } from '../modules/Linking'
 import { defaultUserPreferences, UserPreferences } from '../modules/Storage'
 import { getLegacyMigrationPreview, hasLegacyMigrationCompleted, runLegacyMigration } from '../services/legacyMigration'
@@ -117,7 +117,7 @@ export const Settings = () => {
   }, [legacyMigrationDone])
 
   return (
-    <View style={styles.container}>
+    <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollContent}>
       <Text style={styles.sectionTitle}>{t('settings')}</Text>
 
       <View border="light" rounded="medium" style={styles.box}>
@@ -196,11 +196,28 @@ export const Settings = () => {
 
         <Divider />
 
-        <Row align="center" justify="start" style={styles.boxItem}>
-          <Checkbox
+        <Row align="center" justify="between" style={styles.boxItem}>
+          <Text style={styles.itemLabel}>{t('openOnStartup')}</Text>
+          <Switch
+            value={preferences.launchOnLogin}
+            onValueChange={(value) => updatePreference('launchOnLogin', value)}
+          />
+        </Row>
+
+        <Divider />
+
+        <Row align="center" justify="between" style={styles.boxItem}>
+          <Text style={styles.itemLabel}>{t('showAppIcons')}</Text>
+          <Switch value={preferences.showAppIcons} onValueChange={(value) => updatePreference('showAppIcons', value)} />
+        </Row>
+
+        <Divider />
+
+        <Row align="center" justify="between" style={styles.boxItem}>
+          <Text style={styles.itemLabel}>{t('deleteFilesFromDiskByDefault')}</Text>
+          <Switch
             value={preferences.removeFromDiskByDefault}
             onValueChange={(value) => updatePreference('removeFromDiskByDefault', value)}
-            label={t('deleteFilesFromDiskByDefault')}
           />
         </Row>
       </View>
@@ -329,15 +346,20 @@ export const Settings = () => {
           <Text style={styles.releaseButtonText}>Releases</Text>
         </TouchableOpacity>
       </View>
-    </View>
+    </ScrollView>
   )
 }
 
 const styles = StyleSheet.create({
-  container: {
+  scrollView: {
     flex: 1,
+    minHeight: 0,
+  },
+  scrollContent: {
+    flexGrow: 1,
     padding: 16,
     paddingTop: 12,
+    paddingBottom: 16,
   },
   sectionTitle: {
     fontSize: 14,
@@ -406,7 +428,7 @@ const styles = StyleSheet.create({
     fontWeight: '600',
   },
   footer: {
-    marginTop: 'auto',
+    marginTop: 20,
     paddingTop: 14,
     alignItems: 'center',
     gap: 4,

--- a/apps/menu-bar/src/windows/Settings.web.tsx
+++ b/apps/menu-bar/src/windows/Settings.web.tsx
@@ -1,0 +1,473 @@
+import { Ionicons } from '@expo/vector-icons'
+import { Picker } from '@react-native-picker/picker'
+import React, { useEffect, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { StyleSheet, TouchableOpacity } from 'react-native'
+import { installCli, isCliInstalled, uninstallCli } from '../../modules/shell-utils/src'
+import Analytics, { AnalyticsEvent } from '../analytics'
+import { Divider, Row, ScrollView, Switch, Text, View } from '../components'
+import { Linking } from '../modules/Linking'
+import { defaultUserPreferences, UserPreferences } from '../modules/Storage'
+import { getLegacyMigrationPreview, hasLegacyMigrationCompleted, runLegacyMigration } from '../services/legacyMigration'
+import {
+  getEditorOptions,
+  getTerminalOptions,
+  initializeToolOptions,
+  loadPreferences,
+  persistPreferences,
+  reloadToolOptions,
+  subscribePreferencesChange,
+} from '../services/preferences'
+import { WindowsNavigator } from './index'
+
+const LOCALE_OPTIONS = [
+  { label: '🇺🇸 English', value: 'en' },
+  { label: '🇧🇷 Portuguese', value: 'pt' },
+  { label: '🇪🇸 Spanish', value: 'es' },
+] as const
+
+const REPOSITORY_URL = 'https://github.com/thejoaov/tray-link'
+const RELEASES_URL = 'https://github.com/thejoaov/tray-link/releases'
+const CREATOR_URL = 'https://github.com/thejoaov'
+
+export const Settings = () => {
+  const { t } = useTranslation()
+  const [preferences, setPreferences] = useState<UserPreferences>(defaultUserPreferences)
+  const [reloadingTools, setReloadingTools] = useState(false)
+  const [toolsVersion, setToolsVersion] = useState(0)
+  const [toolsReady, setToolsReady] = useState(false)
+  const [migratingLegacyData, setMigratingLegacyData] = useState(false)
+  const [legacyMigrationDone, setLegacyMigrationDone] = useState(false)
+  const [legacyProjectsPreviewCount, setLegacyProjectsPreviewCount] = useState(0)
+  const [cliInstalled, setCliInstalled] = useState(false)
+  const [installingCli, setInstallingCli] = useState(false)
+
+  const editorOptions = useMemo(
+    () => getEditorOptions(preferences.customEditors),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [preferences.customEditors, toolsVersion],
+  )
+
+  const terminalOptions = useMemo(
+    () => getTerminalOptions(preferences.customTerminals),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [preferences.customTerminals, toolsVersion],
+  )
+
+  const updatePreference = async <K extends keyof UserPreferences>(key: K, value: UserPreferences[K]) => {
+    const next = { ...preferences, [key]: value }
+    setPreferences(next)
+    await persistPreferences(next)
+  }
+
+  useEffect(() => {
+    // Load preferences asynchronously on mount
+    loadPreferences()
+      .then(setPreferences)
+      .catch((e) => {
+        Analytics.track(AnalyticsEvent.ERROR, { error: String(e) })
+      })
+
+    const subscription = subscribePreferencesChange(() => {
+      loadPreferences()
+        .then(setPreferences)
+        .catch((e) => {
+          Analytics.track(AnalyticsEvent.ERROR, { error: String(e) })
+        })
+      setToolsVersion((v) => v + 1)
+    })
+
+    // Check legacy migration status
+    hasLegacyMigrationCompleted()
+      .then(setLegacyMigrationDone)
+      .catch((e) => {
+        Analytics.track(AnalyticsEvent.ERROR, { error: String(e) })
+      })
+
+    // Discover tools on mount (needed because Settings runs in a separate BrowserWindow)
+    initializeToolOptions()
+      .then(() => {
+        setToolsVersion((v) => v + 1)
+        setToolsReady(true)
+      })
+      .catch(() => {
+        // Force a version bump even on error so the UI reflects whatever was discovered
+        setToolsVersion((v) => v + 1)
+        setToolsReady(true)
+      })
+
+    // Check CLI install status
+    isCliInstalled()
+      .then(setCliInstalled)
+      .catch(() => setCliInstalled(false))
+
+    return () => {
+      subscription.remove()
+    }
+  }, [])
+
+  useEffect(() => {
+    getLegacyMigrationPreview()
+      .then((preview) => {
+        setLegacyProjectsPreviewCount(preview?.projectsCount ?? 0)
+      })
+      .catch(() => {
+        setLegacyProjectsPreviewCount(0)
+      })
+  }, [legacyMigrationDone])
+
+  return (
+    <View style={styles.root}>
+      <ScrollView contentContainerStyle={styles.scrollContent} indicatorStyle="black">
+        <Text style={styles.sectionTitle}>{t('settings')}</Text>
+
+        <View border="light" rounded="medium" style={styles.box}>
+          <Row align="center" justify="between" style={styles.boxItem}>
+            <Text style={styles.itemLabel}>{t('language')}</Text>
+
+            <Picker
+              selectedValue={preferences.locale}
+              onValueChange={(value) => updatePreference('locale', value)}
+              style={styles.picker}
+            >
+              {LOCALE_OPTIONS.map((option) => (
+                <Picker.Item key={option.value} label={option.label} value={option.value} />
+              ))}
+            </Picker>
+          </Row>
+
+          <Divider />
+
+          <Row align="center" justify="between" style={styles.boxItem}>
+            <Text style={styles.itemLabel}>{t('defaultEditor')}</Text>
+            <Row align="center" style={styles.controlRow}>
+              <Picker
+                selectedValue={preferences.defaultEditor}
+                onValueChange={(value) => {
+                  if (!toolsReady) return
+                  updatePreference('defaultEditor', value)
+                }}
+                enabled={toolsReady}
+                style={styles.picker}
+              >
+                <Picker.Item label={t('systemDefault')} value={null} />
+                {editorOptions.map((option) => (
+                  <Picker.Item key={option.command} label={option.label} value={option.command} />
+                ))}
+              </Picker>
+
+              <TouchableOpacity
+                accessibilityLabel={t('addCustomEditor')}
+                onPress={() => WindowsNavigator.open('CustomEditorWindow')}
+                style={styles.iconButton}
+              >
+                <Ionicons name="add" size={16} color="var(--text-color)" />
+              </TouchableOpacity>
+            </Row>
+          </Row>
+
+          <Divider />
+
+          <Row align="center" justify="between" style={styles.boxItem}>
+            <Text style={styles.itemLabel}>{t('defaultTerminal')}</Text>
+            <Row align="center" style={styles.controlRow}>
+              <Picker
+                selectedValue={preferences.defaultTerminal}
+                onValueChange={(value) => {
+                  if (!toolsReady) return
+                  updatePreference('defaultTerminal', value)
+                }}
+                enabled={toolsReady}
+                style={styles.picker}
+              >
+                <Picker.Item label={t('systemDefault')} value={null} />
+                {terminalOptions.map((option) => (
+                  <Picker.Item key={option.command} label={option.label} value={option.command} />
+                ))}
+              </Picker>
+              <TouchableOpacity
+                accessibilityLabel={t('addCustomTerminal')}
+                onPress={() => WindowsNavigator.open('CustomTerminalWindow')}
+                style={styles.iconButton}
+              >
+                <Ionicons name="add" size={16} color="var(--text-color)" />
+              </TouchableOpacity>
+            </Row>
+          </Row>
+
+          <Divider />
+
+          <Row align="center" justify="between" style={styles.boxItem}>
+            <Text style={styles.itemLabel}>{t('openOnStartup')}</Text>
+            <Switch
+              value={preferences.launchOnLogin}
+              onValueChange={(value) => updatePreference('launchOnLogin', value)}
+            />
+          </Row>
+
+          <Divider />
+
+          <Row align="center" justify="between" style={styles.boxItem}>
+            <Text style={styles.itemLabel}>{t('showAppIcons')}</Text>
+            <Switch
+              value={preferences.showAppIcons}
+              onValueChange={(value) => updatePreference('showAppIcons', value)}
+            />
+          </Row>
+
+          <Divider />
+
+          <Row align="center" justify="between" style={styles.boxItem}>
+            <Text style={styles.itemLabel}>{t('deleteFilesFromDiskByDefault')}</Text>
+            <Switch
+              value={preferences.removeFromDiskByDefault}
+              onValueChange={(value) => updatePreference('removeFromDiskByDefault', value)}
+            />
+          </Row>
+        </View>
+
+        <Text style={[styles.sectionTitle, styles.sectionTitleMargin]}>{t('cli')}</Text>
+
+        <View border="light" rounded="medium" style={styles.box}>
+          <Row align="center" justify="between" style={styles.boxItem}>
+            <View style={styles.itemTextContainer}>
+              <Text style={styles.itemLabel}>{t(cliInstalled ? 'uninstallCli' : 'installCli')} CLI</Text>
+              <Text style={styles.itemDescription}>{cliInstalled ? t('cliInstalled') : t('cliNotInstalled')}</Text>
+            </View>
+            <TouchableOpacity
+              accessibilityLabel={cliInstalled ? t('uninstallCli') : t('installCli')}
+              disabled={installingCli}
+              onPress={async () => {
+                setInstallingCli(true)
+                try {
+                  if (cliInstalled) {
+                    const result = await uninstallCli()
+                    if (result.success) {
+                      setCliInstalled(false)
+                    }
+                  } else {
+                    const result = await installCli()
+                    if (result.success) {
+                      setCliInstalled(true)
+                    }
+                  }
+                } finally {
+                  setInstallingCli(false)
+                }
+              }}
+              style={[styles.button, installingCli && styles.buttonDisabled]}
+            >
+              <Ionicons
+                name={cliInstalled ? 'close-circle-outline' : 'terminal-outline'}
+                size={14}
+                color="var(--text-color)"
+              />
+              <Text style={styles.buttonText}>{t(cliInstalled ? 'uninstallCli' : 'installCli')}</Text>
+            </TouchableOpacity>
+          </Row>
+        </View>
+
+        <Text style={[styles.sectionTitle, styles.sectionTitleMargin]}>{t('advanced') || 'Advanced'}</Text>
+
+        <View border="light" rounded="medium" style={styles.box}>
+          <Row align="center" justify="between" style={styles.boxItem}>
+            <View style={styles.itemTextContainer}>
+              <Text style={styles.itemLabel}>{t('reloadToolList') || 'Reload tool list'}</Text>
+            </View>
+            <TouchableOpacity
+              accessibilityLabel={t('reloadToolList')}
+              disabled={reloadingTools}
+              onPress={async () => {
+                setReloadingTools(true)
+                try {
+                  await reloadToolOptions()
+                } finally {
+                  setToolsVersion((v) => v + 1)
+                  setToolsReady(true)
+                  setReloadingTools(false)
+                }
+              }}
+              style={[styles.button, reloadingTools && styles.buttonDisabled]}
+            >
+              <Ionicons name="refresh" size={14} color="var(--text-color)" />
+              <Text style={styles.buttonText}>{t('reload')}</Text>
+            </TouchableOpacity>
+          </Row>
+
+          <Divider />
+
+          <Row align="center" justify="between" style={styles.boxItem}>
+            <View style={styles.itemTextContainer}>
+              <Text style={styles.itemLabel}>{t('migrateLegacyData')}</Text>
+              <Text style={styles.itemDescription}>
+                {legacyProjectsPreviewCount > 0
+                  ? t('migrationPreviewFound', {
+                      projects: String(legacyProjectsPreviewCount),
+                    })
+                  : t('migrationPreviewNone')}
+              </Text>
+            </View>
+            <TouchableOpacity
+              accessibilityLabel={t('migrateLegacyData')}
+              disabled={legacyMigrationDone || migratingLegacyData}
+              onPress={async () => {
+                setMigratingLegacyData(true)
+                try {
+                  const migrated = await runLegacyMigration()
+                  const done = await hasLegacyMigrationCompleted()
+                  if (migrated || done) {
+                    setLegacyMigrationDone(true)
+                    setLegacyProjectsPreviewCount(0)
+                  }
+                } finally {
+                  setMigratingLegacyData(false)
+                }
+              }}
+              style={[styles.button, (legacyMigrationDone || migratingLegacyData) && styles.buttonDisabled]}
+            >
+              <Ionicons name="download-outline" size={14} color="var(--text-color)" />
+              <Text style={styles.buttonText}>{t('migrate') || 'Migrate'}</Text>
+            </TouchableOpacity>
+          </Row>
+        </View>
+
+        <View style={styles.footer}>
+          <TouchableOpacity
+            accessibilityLabel="Open tray-link repository"
+            onPress={() => Linking.openURL(REPOSITORY_URL)}
+          >
+            <Text style={styles.footerLink}>github.com/thejoaov/tray-link</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            accessibilityLabel="Open creator GitHub profile"
+            onPress={() => Linking.openURL(CREATOR_URL)}
+          >
+            <Text style={styles.footerSubtle}>Created by @thejoaov</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            accessibilityLabel="Open releases page"
+            onPress={() => Linking.openURL(RELEASES_URL)}
+            style={styles.releaseButton}
+          >
+            <Ionicons name="rocket-outline" size={14} color="var(--text-color)" />
+            <Text style={styles.releaseButtonText}>Releases</Text>
+          </TouchableOpacity>
+        </View>
+      </ScrollView>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    minHeight: 0,
+    maxHeight: '100%',
+  },
+  scrollView: {
+    flex: 1,
+    minHeight: 0,
+  },
+  scrollContent: {
+    flexGrow: 1,
+    padding: 16,
+    paddingTop: 12,
+    paddingBottom: 16,
+  },
+  sectionTitle: {
+    fontSize: 14,
+    fontWeight: '600',
+    marginBottom: 8,
+    marginLeft: 4,
+  },
+  sectionTitleMargin: {
+    marginTop: 20,
+  },
+  box: {
+    overflow: 'hidden',
+    backgroundColor: 'rgba(150, 150, 150, 0.05)',
+  },
+  boxItem: {
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+  itemTextContainer: {
+    flex: 1,
+    paddingRight: 16,
+    justifyContent: 'center',
+  },
+  itemLabel: {
+    fontSize: 13,
+    fontWeight: '500',
+  },
+  itemDescription: {
+    fontSize: 11,
+    opacity: 0.6,
+    marginTop: 4,
+  },
+  controlRow: {
+    gap: 8,
+  },
+  picker: {
+    borderWidth: 0,
+    borderRadius: 6,
+    width: 160,
+    height: 28,
+    color: 'var(--text-color)',
+    backgroundColor: 'rgba(150, 150, 150, 0.1)',
+  },
+  iconButton: {
+    width: 28,
+    height: 28,
+    borderRadius: 6,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'rgba(150, 150, 150, 0.1)',
+  },
+  button: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    borderRadius: 6,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    backgroundColor: 'rgba(150, 150, 150, 0.1)',
+  },
+  buttonDisabled: {
+    opacity: 0.5,
+  },
+  buttonText: {
+    fontSize: 12,
+    fontWeight: '600',
+  },
+  footer: {
+    marginTop: 20,
+    paddingTop: 14,
+    alignItems: 'center',
+    gap: 4,
+  },
+  footerLink: {
+    fontSize: 12,
+    fontWeight: '600',
+    textDecorationLine: 'underline',
+    opacity: 0.9,
+  },
+  footerSubtle: {
+    fontSize: 11,
+    opacity: 0.65,
+  },
+  releaseButton: {
+    marginTop: 8,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 7,
+    backgroundColor: 'rgba(150, 150, 150, 0.1)',
+  },
+  releaseButtonText: {
+    fontSize: 12,
+    fontWeight: '600',
+  },
+})

--- a/apps/menu-bar/src/windows/index.ts
+++ b/apps/menu-bar/src/windows/index.ts
@@ -1,8 +1,8 @@
-import React, { ComponentType } from 'react'
+import React, { ComponentType, useEffect } from 'react'
 import { AppRegistry, Platform } from 'react-native'
 import { FluentProvider } from '../providers/FluentProvider'
 import { ThemeProvider } from '../providers/ThemeProvider'
-import { i18n } from '../services/i18n'
+import { i18n, subscribeLanguageSync, syncI18nLanguageFromPreferences } from '../services/i18n'
 import { CustomEditorWindow } from './CustomEditorWindow'
 import { CustomTerminalWindow } from './CustomTerminalWindow'
 import { RemoveProjectWindow } from './RemoveProjectWindow'
@@ -48,12 +48,29 @@ export const WindowsList = [
 
 const WINDOW_OPTIONS_MAP = Object.fromEntries(WindowsList.map((w) => [w.name, w.options]))
 
+function WindowBootstrap({ children }: { children: React.ReactNode }) {
+  useEffect(() => {
+    syncI18nLanguageFromPreferences().catch(() => undefined)
+    const languageSubscription = subscribeLanguageSync()
+
+    return () => {
+      languageSubscription.remove()
+    }
+  }, [])
+
+  return React.createElement(React.Fragment, null, children)
+}
+
 function wrapWithProviders(Component: ComponentType) {
   return function WrappedWindow() {
     return React.createElement(
-      ThemeProvider,
-      { themePreference: 'no-preference', children: undefined },
-      React.createElement(FluentProvider, null, React.createElement(Component)),
+      WindowBootstrap,
+      null,
+      React.createElement(
+        ThemeProvider,
+        { themePreference: 'no-preference', children: undefined },
+        React.createElement(FluentProvider, null, React.createElement(Component)),
+      ),
     )
   }
 }

--- a/apps/menu-bar/src/windows/index.ts
+++ b/apps/menu-bar/src/windows/index.ts
@@ -12,22 +12,37 @@ export const WindowsList = [
   {
     name: 'Settings',
     component: Settings,
-    options: { title: 'Settings', width: 400, height: 680, resizable: false },
+    options: { title: 'Settings', width: 400, height: 500, resizable: false },
   },
   {
     name: 'CustomEditorWindow',
     component: CustomEditorWindow,
-    options: { title: i18n.t('addCustomEditor'), width: 420, height: 360, resizable: false },
+    options: {
+      title: i18n.t('addCustomEditor'),
+      width: 420,
+      height: 360,
+      resizable: false,
+    },
   },
   {
     name: 'CustomTerminalWindow',
     component: CustomTerminalWindow,
-    options: { title: i18n.t('addCustomTerminal'), width: 420, height: 360, resizable: false },
+    options: {
+      title: i18n.t('addCustomTerminal'),
+      width: 420,
+      height: 360,
+      resizable: false,
+    },
   },
   {
     name: 'RemoveProjectWindow',
     component: RemoveProjectWindow,
-    options: { title: i18n.t('removeProjectTitle'), width: 420, height: 260, resizable: false },
+    options: {
+      title: i18n.t('removeProjectTitle'),
+      width: 420,
+      height: 260,
+      resizable: false,
+    },
   },
 ]
 

--- a/packages/common-types/src/index.ts
+++ b/packages/common-types/src/index.ts
@@ -38,6 +38,7 @@ export interface Settings {
   defaultEditor: string | null
   defaultTerminal: string | null
   launchOnLogin: boolean
+  showAppIcons: boolean
   removeFromDiskByDefault: boolean
   customEditors: CustomTool[]
   customTerminals: CustomTool[]


### PR DESCRIPTION
# Summary

This PR adds startup and app icon preferences to the menu bar settings, improves editor/terminal icon discovery across platforms, and fixes Electron-specific issues around real app icon rendering, Settings scrolling, and locale sync in child windows.

## Features introduced

- Startup and real app icon preferences for menu bar tools [ad64831](https://github.com/thejoaov/tray-link/commit/ad648313d70fbf18ad54db77f119708f3b2b2c75)
- Platform-specific AppIcon/Settings support for web and Electron rendering [ad64831](https://github.com/thejoaov/tray-link/commit/ad648313d70fbf18ad54db77f119708f3b2b2c75), [8d7cd1a](https://github.com/thejoaov/tray-link/commit/8d7cd1a)

## Bug fixes

- Resolve real macOS app icons in Electron instead of generic placeholders [719f98a](https://github.com/thejoaov/tray-link/commit/719f98a)

- Restore Settings scrolling and locale sync in Electron child windows [8d7cd1a](https://github.com/thejoaov/tray-link/commit/8d7cd1a), [ad32ed1](https://github.com/thejoaov/tray-link/commit/ad32ed1)